### PR TITLE
Uber standard no stdin

### DIFF
--- a/.arcanist/uber-standard/uber-standard/UberStandardLinter.php
+++ b/.arcanist/uber-standard/uber-standard/UberStandardLinter.php
@@ -57,12 +57,8 @@ final class UberStandardLinter extends ArcanistExternalLinter {
     return true;
   }
 
-  public function supportsReadDataFromStdin() {
-    return true;
-  }
-
   protected function getMandatoryFlags() {
-    $options = array('--reporter=json', '--stdin');
+    $options = array('--reporter=json');
     return $options;
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uber-dot-arcanist",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Uber's .arcanist folder as an npm module",
   "main": "dot-arcanist.js",
   "scripts": {


### PR DESCRIPTION
arc lint gives more detailed information if you don't use stdin, so switching to that approach.