### PR TITLE
define maxLineLength in LintTrapLinter

### DIFF
--- a/.arcanist/lint-trap/lint-trap/LintTrapLinter.php
+++ b/.arcanist/lint-trap/lint-trap/LintTrapLinter.php
@@ -7,6 +7,7 @@ final class LintTrapLinter extends ArcanistExternalLinter {
 
   private $lintignore;
   private $lintrc;
+  private $maxLineLength;
 
   public function getInfoName() {
     return 'LintTrap';


### PR DESCRIPTION
Fix for this bug:

```
Exception
Undefined property: LintTrapLinter::$maxLineLength
(Run with `--trace` for a full exception trace.)
```

cc @malandrew 